### PR TITLE
Support reset to anonymous after automatic linking failure

### DIFF
--- a/Example/RxFireAuth macOS/ViewController.swift
+++ b/Example/RxFireAuth macOS/ViewController.swift
@@ -132,13 +132,18 @@ class ViewController: NSViewController {
         })
         .disposed(by: self.disposeBag)
     } else {
-			self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: self.migrationAllowance, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
-        .subscribe(onSuccess: { [unowned self] in
-          self.handleLoggedIn($0)
-        }, onFailure: { [unowned self] in
-          self.handleSignInError(error: $0)
-        })
-        .disposed(by: self.disposeBag)
+			userManager.login(
+				with: .password(email: self.loginField.stringValue, password: self.passwordField.stringValue),
+				updateUserDisplayName: true,
+				allowMigration: migrationAllowance,
+				resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on
+			)
+			.subscribe(onSuccess: { [unowned self] in
+				self.handleLoggedIn($0)
+			}, onFailure: { [unowned self] in
+				self.handleSignInError(error: $0)
+			})
+			.disposed(by: self.disposeBag)
     }
   }
   
@@ -266,7 +271,7 @@ class ViewController: NSViewController {
       }
       
       self.toggleProgress(true)
-      self.userManager.confirmAuthentication(email: email, password: password)
+			userManager.confirmAuthentication(with: .password(email: email, password: password))
         .observe(on: MainScheduler.instance)
         .subscribe(onCompleted: { [unowned self] in
           self.toggleProgress(false)
@@ -319,7 +324,7 @@ class ViewController: NSViewController {
     
     alert.beginSheetModal(for: view.window!) { [unowned self] (response) in
       if response == .alertFirstButtonReturn {
-        self.userManager.confirmAuthentication(email: self.userManager.user!.email!, password: textField.stringValue)
+				userManager.confirmAuthentication(with: .password(email: self.userManager.user!.email!, password: textField.stringValue))
           .observe(on: MainScheduler.instance)
           .subscribe(onCompleted: { [unowned self] in
             self.setNewPassword()
@@ -365,13 +370,23 @@ class ViewController: NSViewController {
       switch response {
       case .alertFirstButtonReturn:
         if let credentials = credentials {
-          self.userManager.login(with: credentials, updateUserDisplayName: true, allowMigration: true, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
-            .subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
-            .disposed(by: self.disposeBag)
+					self.userManager.login(
+						with: credentials,
+						updateUserDisplayName: true,
+						allowMigration: true,
+						resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on
+					)
+					.subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
+					.disposed(by: self.disposeBag)
         } else {
-          self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: true, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
-            .subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
-            .disposed(by: self.disposeBag)
+					self.userManager.login(
+						with: .password(email: self.loginField.stringValue, password: self.passwordField.stringValue),
+						updateUserDisplayName: true,
+						allowMigration: true,
+						resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on
+					)
+					.subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
+					.disposed(by: self.disposeBag)
         }
       default:
         break

--- a/Example/RxFireAuth macOS/ViewController.swift
+++ b/Example/RxFireAuth macOS/ViewController.swift
@@ -132,7 +132,7 @@ class ViewController: NSViewController {
         })
         .disposed(by: self.disposeBag)
     } else {
-      self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: self.migrationAllowance)
+			self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: self.migrationAllowance, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
         .subscribe(onSuccess: { [unowned self] in
           self.handleLoggedIn($0)
         }, onFailure: { [unowned self] in
@@ -365,11 +365,11 @@ class ViewController: NSViewController {
       switch response {
       case .alertFirstButtonReturn:
         if let credentials = credentials {
-          self.userManager.login(with: credentials, updateUserDisplayName: true, allowMigration: true)
+          self.userManager.login(with: credentials, updateUserDisplayName: true, allowMigration: true, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
             .subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
             .disposed(by: self.disposeBag)
         } else {
-          self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: true)
+          self.userManager.login(email: self.loginField.stringValue, password: self.passwordField.stringValue, allowMigration: true, resetToAnonymousOnFailure: resetAnonymousCheckbox.state == .on)
             .subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
             .disposed(by: self.disposeBag)
         }
@@ -418,7 +418,9 @@ class ViewController: NSViewController {
   }
   
   private func show(error: Error) {
-    self.show(title: "An error occurred!", message: error.localizedDescription)
+		toggleProgress(false) { [weak self] in
+			self?.show(title: "An error occurred!", message: error.localizedDescription)
+		}
   }
   
   private func show(title: String, message: String) {

--- a/Example/RxFireAuth/ViewController.swift
+++ b/Example/RxFireAuth/ViewController.swift
@@ -133,9 +133,9 @@ class ViewController: UITableViewController {
         .disposed(by: self.disposeBag)
     } else {
 			self.userManager.login(
-				email: self.loginField.text!,
-				password: self.passwordField.text!,
-				allowMigration: self.migrationAllowance,
+				with: .password(email: loginField.text!, password: passwordField.text!),
+				updateUserDisplayName: true,
+				allowMigration: migrationAllowance,
 				resetToAnonymousOnFailure: resetAnononymousSwitch.isOn
 			)
 			.subscribe(onSuccess: { [unowned self] in
@@ -270,7 +270,7 @@ class ViewController: UITableViewController {
       }
       
       self.toggleProgress(true)
-      self.userManager.confirmAuthentication(email: email, password: password)
+			self.userManager.confirmAuthentication(with: .password(email: email, password: password))
 				.observe(on: MainScheduler.instance)
         .subscribe(onCompleted: { [unowned self] in
           self.toggleProgress(false)
@@ -322,7 +322,7 @@ class ViewController: UITableViewController {
     alertController.addAction(UIAlertAction(title: "Confirm", style: .default, handler: { [unowned self] _ in
       alertController.dismiss(animated: true)
       
-      self.userManager.confirmAuthentication(email: self.userManager.user!.email!, password: alertController.textFields!.first!.text!)
+			userManager.confirmAuthentication(with: .password(email: self.userManager.user!.email!, password: alertController.textFields!.first!.text!))
 				.observe(on: MainScheduler.instance)
         .subscribe(onCompleted: { [unowned self] in
           self.setNewPassword()
@@ -379,9 +379,14 @@ class ViewController: UITableViewController {
 						.subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
 						.disposed(by: self.disposeBag)
 				} else {
-					self.userManager.login(email: self.loginField.text!, password: self.passwordField.text!, allowMigration: true, resetToAnonymousOnFailure: self.resetAnononymousSwitch.isOn)
-						.subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
-						.disposed(by: self.disposeBag)
+					self.userManager.login(
+						with: .password(email: self.loginField.text!, password: self.passwordField.text!),
+						updateUserDisplayName: true,
+						allowMigration: true,
+						resetToAnonymousOnFailure: self.resetAnononymousSwitch.isOn
+					)
+					.subscribe(onSuccess: self.handleLoggedIn(_:), onFailure: self.show(error:))
+					.disposed(by: self.disposeBag)
 				}
 			}))
 			migrationAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel))

--- a/RxFireAuth/Classes/UserError.swift
+++ b/RxFireAuth/Classes/UserError.swift
@@ -57,6 +57,8 @@ public enum UserError: LocalizedError {
   case invalidConfiguration
   /// An error occurred while attempting to access the keychain.
   case keychainError(Error?)
+	/// An error occurred while attempting to link an anonymous user account to an existing account.
+	case automaticLinkingFailed(LoginDescriptor?, Error)
   /// An unknown error has occurred.
   case unknown(Error?)
   
@@ -87,7 +89,7 @@ public enum UserError: LocalizedError {
     case .wrongPassword:
       return "The specified password is invalid."
     case .invalidCredential:
-      return "The specified credential is invalid."
+      return "The specified credentials are invalid."
     case .emailAlreadyInUse:
       return "This email address is already registered with another account."
     case .weakPassword(let reason):
@@ -106,6 +108,8 @@ public enum UserError: LocalizedError {
       return "There is an error in your app configuration."
     case .keychainError(let error):
       return "An error occurred while comunicating with the keychain: \(error?.localizedDescription ?? "unknown")"
+		case let .automaticLinkingFailed(_, internalError):
+			return "An error occurred while attempting to link this anonymous account with the existing one with the provided credentials: \(internalError.localizedDescription)"
     }
   }
   

--- a/RxFireAuth/Classes/UserManager+Providers.swift
+++ b/RxFireAuth/Classes/UserManager+Providers.swift
@@ -56,11 +56,12 @@ extension UserManager: LoginProviderManagerType {
   public func signInWithApple(in viewController: ViewController, updateUserDisplayName: Bool, allowMigration: Bool?) -> Single<LoginDescriptor> {
     return self.signInWithAppleHandler(in: viewController)
       .flatMap { [unowned self] credentials in
-        self.login(
+        performLogin(
 					with: credentials,
 					updateUserDisplayName: updateUserDisplayName, 
 					allowMigration: allowMigration,
-					credentialsProvider: signInWithAppleHandler(in: viewController)
+					externalCredentialsProvider: signInWithAppleHandler(in: viewController),
+					resetToAnonymousOnFailure: false
 				)
       }
   }
@@ -111,11 +112,12 @@ extension UserManager: LoginProviderManagerType {
   public func signInWithGoogle(as clientId: String, in viewController: ViewController, updateUserDisplayName: Bool, allowMigration: Bool?) -> Single<LoginDescriptor> {
     return self.signInWithGoogleHandler(as: clientId, in: viewController)
       .flatMap { [unowned self] credentials in
-        self.login(
+        performLogin(
 					with: credentials,
 					updateUserDisplayName: updateUserDisplayName,
 					allowMigration: allowMigration,
-					credentialsProvider: signInWithGoogleHandler(as: clientId, in: viewController)
+					externalCredentialsProvider: signInWithGoogleHandler(as: clientId, in: viewController),
+					resetToAnonymousOnFailure: false
 				)
       }
   }

--- a/RxFireAuth/Classes/UserManager.swift
+++ b/RxFireAuth/Classes/UserManager.swift
@@ -10,7 +10,8 @@ import FirebaseAuth
 import RxSwift
 
 enum UserInternalError: Error {
-	case duplicatedCredentials
+	case 	duplicatedCredentials,
+				automaticLinkingFailed(oldUserId: String?, internalError: Error)
 }
 
 /// The default implementation of `UserManagerType`.
@@ -119,52 +120,8 @@ public class UserManager: UserManagerType {
       }
   }
   
-  public func accountExists(with email: String) -> Single<Bool> {
-    return Single.create { [unowned self] (observer) -> Disposable in
-      let disposable = Disposables.create { }
-      
-      Auth.auth().fetchSignInMethods(forEmail: email) { [unowned self] (methods,
-                                                                        error) in
-        guard !disposable.isDisposed else { return }
-        
-        if let error = error {
-          observer(.failure(self.map(error: error)))
-        } else if let methods = methods, methods.count > 0 {
-          observer(.success(true))
-        } else {
-          observer(.success(false))
-        }
-      }
-      
-      return disposable
-    }
-  }
-  
-  public func register(email: String, password: String) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard !self.isLoggedIn else { return .error(UserError.alreadyLoggedIn) }
-      
-      if Auth.auth().currentUser?.isAnonymous == true {
-        return self.linkAnonymousAccount(toEmail: email, password: password)
-      }
-      
-      return Completable.create { (observer) -> Disposable in
-        let disposable = Disposables.create { }
-        
-        Auth.auth().createUser(withEmail: email, password: password) { (_, error) in
-          guard !disposable.isDisposed else { return }
-          if let error = error {
-            observer(.error(self.map(error: error)))
-          } else {
-            observer(.completed)
-          }
-        }
-        
-        return disposable
-      }
-    }
-  }
-  
+	// MARK: - Login
+	
   public func loginAnonymously() -> Completable {
     return Completable.deferred { [unowned self] in
       guard !self.isLoggedIn else { return .error(UserError.alreadyLoggedIn) }
@@ -187,24 +144,243 @@ public class UserManager: UserManagerType {
     }
   }
   
-  /// Link the passed user to the Email & Password authentication provider.
-  ///
-  /// - parameters:
-  ///     - user: A user.
-  ///     - email: The email address.
-  ///     - password: A password.
-  /// - returns: A Completable action to observe.
-  private func link(user: User, toEmail email: String, withPassword password: String) -> Completable {
-    return Completable.create { [unowned self] (observer) -> Disposable in
+	@available(*, deprecated, renamed: "login(with:updateUserDisplayName:allowMigration:resetToAnonymousOnFailure:)", message: "Invoke the generic login function passing `Credentials.password`.")
+	public func login(
+		email: String,
+		password: String,
+		allowMigration: Bool?,
+		resetToAnonymousOnFailure: Bool
+	) -> Single<LoginDescriptor> {
+		login(
+			with: .password(email: email, password: password),
+			updateUserDisplayName: true,
+			allowMigration: allowMigration,
+			resetToAnonymousOnFailure: resetToAnonymousOnFailure
+		)
+  }
+	
+	public func login(
+		with credentials: Credentials,
+		updateUserDisplayName: Bool,
+		allowMigration: Bool? = nil,
+		resetToAnonymousOnFailure: Bool
+	) -> Single<LoginDescriptor> {
+    performLogin(
+			with: credentials,
+			updateUserDisplayName: updateUserDisplayName,
+			allowMigration: allowMigration,
+			externalCredentialsProvider: nil,
+			resetToAnonymousOnFailure: resetToAnonymousOnFailure
+		)
+  }
+  
+  public func logout(resetToAnonymous: Bool = false) -> Completable {
+    return Completable.deferred { [unowned self] in
+      if resetToAnonymous && self.isAnonymous { return .error(UserError.alreadyAnonymous) }
+      
+      var logoutAction = Completable.create { (observer) -> Disposable in
+        let disposable = Disposables.create { }
+        
+        do {
+          try Auth.auth().signOut()
+          observer(.completed)
+        } catch {
+          observer(.error(self.map(error: error)))
+        }
+        
+        return disposable
+      }
+      
+      if (resetToAnonymous) {
+        logoutAction = logoutAction
+          .andThen(self.loginAnonymously())
+      }
+      
+      return logoutAction
+    }
+  }
+	
+	// MARK: - Manual Registration
+	
+	public func register(email: String, password: String) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard !self.isLoggedIn else { return .error(UserError.alreadyLoggedIn) }
+			
+			if Auth.auth().currentUser?.isAnonymous == true {
+				return self.linkAnonymousAccount(toEmail: email, password: password)
+			}
+			
+			return Completable.create { (observer) -> Disposable in
+				let disposable = Disposables.create { }
+				
+				Auth.auth().createUser(withEmail: email, password: password) { (_, error) in
+					guard !disposable.isDisposed else { return }
+					if let error = error {
+						observer(.error(self.map(error: error)))
+					} else {
+						observer(.completed)
+					}
+				}
+				
+				return disposable
+			}
+		}
+	}
+	
+	// MARK: - Manual Linking
+	
+	@available(*, deprecated, renamed: "linkAnonymousAccount(to:)", message: "Invoke the generic link function passing `Credentials.password`.")
+	public func linkAnonymousAccount(toEmail email: String, password: String) -> Completable {
+		linkAnonymousAccount(
+			to: .password(
+				email: email,
+				password: password
+			)
+		)
+	}
+	
+	public func linkAnonymousAccount(to credentials: Credentials) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard 
+				let user = Auth.auth().currentUser,
+					user.isAnonymous
+			else { return .error(UserError.noUser) }
+			
+			return self.link(user: user, to: credentials)
+		}
+	}
+	
+	// MARK: - Update User
+	
+	public func update(user: UserData) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard 
+				let currentUser = Auth.auth().currentUser
+			else {
+				return Completable.error(UserError.noUser)
+			}
+			
+			return Completable.create { [unowned self] (observer) -> Disposable in
+				let disposable = Disposables.create { }
+				
+				let changeRequest = currentUser.createProfileChangeRequest()
+				changeRequest.displayName = user.displayName
+				
+				changeRequest.commitChanges { (error) in
+					if let error = error {
+						observer(.error(self.map(error: error)))
+					} else {
+						self.forceRefreshAutoUpdatingUser.onNext(())
+						observer(.completed)
+					}
+				}
+				
+				return disposable
+			}
+		}
+	}
+	
+	public func update(userConfigurationHandler: @escaping (UserData) -> UserData) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard 
+				Auth.auth().currentUser != nil
+			else {
+				return Completable.error(UserError.noUser)
+			}
+			
+			return self.autoupdatingUser
+				.take(1)
+				.filter { $0 != nil }.map { $0! }
+				.map(userConfigurationHandler)
+				.flatMap { [unowned self] in update(user: $0) }
+				.asCompletable()
+		}
+	}
+	
+	// MARK: - Email Management
+	
+	@available(*, deprecated, message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, this query will always return false.")
+	public func accountExists(with email: String) -> Single<Bool> {
+		return Single.create { [unowned self] (observer) -> Disposable in
+			let disposable = Disposables.create { }
+			
+			Auth.auth().fetchSignInMethods(forEmail: email) { [unowned self] (methods,
+																																				error) in
+				guard !disposable.isDisposed else { return }
+				
+				if let error = error {
+					observer(.failure(self.map(error: error)))
+				} else if let methods = methods, methods.count > 0 {
+					observer(.success(true))
+				} else {
+					observer(.success(false))
+				}
+			}
+			
+			return disposable
+		}
+	}
+	
+	@available(*, deprecated, renamed: "verifyAndChange(toNewEmail:)", message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, you should invoke `verifyAndChange(toNewEmail:)` instead.")
+	public func updateEmail(newEmail: String) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
+			
+			return Completable.create { (observer) -> Disposable in
+				let disposable = Disposables.create { }
+				
+				user.updateEmail(to: newEmail) { (error) in
+					if let error = error {
+						observer(.error(self.map(error: error)))
+					} else {
+						observer(.completed)
+					}
+				}
+				
+				return disposable
+			}
+		}
+	}
+	
+	public func verifyAndChange(toNewEmail newEmail: String) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
+			
+			return Completable.create { (observer) -> Disposable in
+				let disposable = Disposables.create { }
+				
+				user.sendEmailVerification(beforeUpdatingEmail: newEmail) { (error) in
+					if let error = error {
+						observer(.error(self.map(error: error)))
+					} else {
+						observer(.completed)
+					}
+				}
+				
+				return disposable
+			}
+		}
+	}
+  
+	// MARK: - Confirm Authentication
+	
+  public func confirmAuthentication(email: String, password: String) -> Completable {
+		confirmAuthentication(
+			with: .password(email: email, password: password)
+		)
+  }
+  
+  public func confirmAuthentication(with loginCredentials: Credentials) -> Completable {
+    return Completable.create { (observer) -> Disposable in
       let disposable = Disposables.create { }
       
-      let credential = EmailAuthProvider.credential(withEmail: email, password: password)
-      user.link(with: credential) { (_, error) in
+      guard let user = Auth.auth().currentUser else { observer(.error(UserError.noUser)); return disposable }
+      
+      user.reauthenticate(with: loginCredentials.asAuthCredentials()) { (_, error) in
         guard !disposable.isDisposed else { return }
         if let error = error {
           observer(.error(self.map(error: error)))
         } else {
-          self.forceRefreshAutoUpdatingUser.onNext(())
           observer(.completed)
         }
       }
@@ -212,37 +388,89 @@ public class UserManager: UserManagerType {
       return disposable
     }
   }
+	
+	// MARK: - Password Management
+	
+	public func updatePassword(newPassword: String) -> Completable {
+		return Completable.deferred { [unowned self] in
+			guard
+				let user = user,
+				let firebaseUser = Auth.auth().currentUser
+			else {
+				return Completable.error(UserError.noUser)
+			}
+			
+			if user.authenticationProviders.contains(.password) {
+				return Completable.create { (observer) -> Disposable in
+					let disposable = Disposables.create { }
+					
+					firebaseUser.updatePassword(to: newPassword) { (error) in
+						guard !disposable.isDisposed else { return }
+						if let error = error {
+							observer(.error(map(error: error)))
+						} else {
+							observer(.completed)
+						}
+					}
+					
+					return disposable
+				}
+			} else {
+				guard
+					let email = user.email
+				else {
+					return Completable.error(UserError.invalidEmail)
+				}
+				
+				return link(
+					user: firebaseUser,
+					to: .password(email: email, password: newPassword)
+				)
+			}
+		}
+	}
+	
+	// MARK: - Delete User
   
-  public func linkAnonymousAccount(toEmail email: String, password: String) -> Completable {
+  public func deleteUser(resetToAnonymous: Bool) -> Completable {
     return Completable.deferred { [unowned self] in
-      guard let user = Auth.auth().currentUser, user.isAnonymous else { return .error(UserError.noUser) }
-      return self.link(user: user, toEmail: email, withPassword: password)
+      guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
+      
+      var deleteAction = Completable.create { (observer) -> Disposable in
+        let disposable = Disposables.create { }
+        
+        user.delete { (error) in
+          guard !disposable.isDisposed else { return }
+          if let error = error {
+            observer(.error(self.map(error: error)))
+          } else {
+            observer(.completed)
+          }
+        }
+        
+        return disposable
+      }
+      
+      if resetToAnonymous {
+        deleteAction = deleteAction
+          .andThen(self.loginAnonymously())
+      }
+      
+      return deleteAction
     }
   }
-  
-  public func login(email: String, password: String, allowMigration: Bool?) -> Single<LoginDescriptor> {
-		login(
-			with: .password(email: email, password: password),
-			updateUserDisplayName: true,
-			allowMigration: allowMigration
-		)
-  }
-  
-  public func loginWithoutChecking(email: String, password: String, allowMigration: Bool?) -> Single<LoginDescriptor> {
-		login(
-			email: email,
-			password: password,
-			allowMigration: allowMigration
-		)
-  }
-  
-	func login(
+}
+
+// MARK: - Login
+extension UserManager {
+	func performLogin(
 		with credentials: Credentials,
 		updateUserDisplayName: Bool,
 		allowMigration: Bool? = nil,
-		credentialsProvider: Single<Credentials>?
+		externalCredentialsProvider: Single<Credentials>?,
+		resetToAnonymousOnFailure: Bool
 	) -> Single<LoginDescriptor> {
-		return Single<LoginDescriptor>.create { [unowned self] observer -> Disposable in
+		Single<LoginDescriptor>.create { [unowned self] observer -> Disposable in
 			let disposable = Disposables.create { }
 			
 			let firebaseCredentials = credentials.asAuthCredentials()
@@ -251,9 +479,11 @@ public class UserManager: UserManagerType {
 			let signInCompletionHandler: (Error?) -> Void = { (error) in
 				guard !disposable.isDisposed else { return }
 				if let error = error {
-					observer(.failure(self.map(error: error)))
+					if (error as NSError).code == AuthErrorCode.invalidCredential.rawValue {
+						observer(.failure(UserInternalError.automaticLinkingFailed(oldUserId: oldUserId, internalError: error)))
+					}
+					observer(.failure(map(error: error)))
 				} else if let newUser = Auth.auth().currentUser {
-					
 					observer(
 						.success(
 							LoginDescriptor(
@@ -308,7 +538,7 @@ public class UserManager: UserManagerType {
 										completionHandler: signInCompletionHandler
 									)
 								} else {
-									/// The provided credential is not reusable, so we cannot login the user
+									/// The provided credentials are not reusable, so we cannot login the user
 									/// again transparently. We have to invoke the same login method again to get new credentials.
 									/// This means that the user will see the login screen twice.
 									observer(.failure(UserInternalError.duplicatedCredentials))
@@ -336,25 +566,60 @@ public class UserManager: UserManagerType {
 			
 			return disposable
 		}
-		.catch({ error in
-			guard
+		.catch { [unowned self] error in
+			if
 				let error = error as? UserInternalError,
-				error == UserInternalError.duplicatedCredentials,
-				let credentialsProvider
-			else {
-				return Single.error(error)
+				case UserInternalError.duplicatedCredentials = error,
+				let externalCredentialsProvider
+			{
+				/// The passed credentials are already linked to an existing account,
+				/// but these credentials are also not reusable, so we cannot login the
+				/// user again transparently. We will now invoke the same function again
+				/// which will cause another login screen to appear.
+				return externalCredentialsProvider
+					.flatMap { (credentials) -> Single<LoginDescriptor> in
+						self.performLogin(
+							with: credentials,
+							updateUserDisplayName: updateUserDisplayName,
+							allowMigration: allowMigration,
+							externalCredentialsProvider: nil,
+							resetToAnonymousOnFailure: resetToAnonymousOnFailure
+						)
+					}
 			}
 			
-			return credentialsProvider
-				.flatMap { (credentials) -> Single<LoginDescriptor> in
-					self.login(
-						with: credentials,
-						updateUserDisplayName: updateUserDisplayName,
-						allowMigration: allowMigration,
-						credentialsProvider: nil
-					)
+			if
+				let error = error as? UserInternalError,
+				case let UserInternalError.automaticLinkingFailed(oldUserId: oldUserId, internalError: internalError) = error
+			{
+				/// The passed credentials are incorrect, so we cannot proceed with the linking.
+				if resetToAnonymousOnFailure {
+					return loginAnonymously()
+						.andThen(
+							autoupdatingUser
+								.take(1)
+						)
+						.asSingle()
+						.flatMap { newUser in
+							Single.error(
+								UserError.automaticLinkingFailed(
+									LoginDescriptor(
+										fullName: nil,
+										performMigration: true,
+										oldUserId: oldUserId,
+										newUserId: newUser?.id
+									),
+									internalError
+								)
+							)
+						}
+				} else {
+					return Single.error(internalError)
 				}
-		})
+			}
+			
+			return Single.error(error)
+		}
 		.flatMap { (loginDescriptor) -> Single<LoginDescriptor> in
 			if updateUserDisplayName, let fullName = loginDescriptor.fullName, fullName.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 {
 				return self.update { (userData) -> UserData in
@@ -367,265 +632,103 @@ public class UserManager: UserManagerType {
 		}
 	}
 	
-  public func login(with credentials: Credentials, updateUserDisplayName: Bool, allowMigration: Bool? = nil) -> Single<LoginDescriptor> {
-    login(
-			with: credentials,
-			updateUserDisplayName: updateUserDisplayName,
-			allowMigration: allowMigration,
-			credentialsProvider: nil
-		)
-  }
-  
-  /// Sign in with the passed credentials in the specified disposable
-  /// and calls the completion handler when done.
-  ///
-  /// To use this function directly, you should wrap it inside an `Observable.create`
-  /// function call. This function will check automatically if the passed disposable has already been
-  /// disposed when coming back from `Auth`'s `signIn(with:)` function.
-  ///
-  /// - parameters:
-  ///     - credentials: The credential to use to sign in.
-  ///     - disposable: A disposable that controls the life of this operation.
-  ///     - completionHandler: A completion handler to call when done.
-  func signIn(with credentials: AuthCredential, in disposable: Cancelable, completionHandler: @escaping (Error?) -> Void) {
-    Auth.auth().signIn(with: credentials) { (_, error) in
-      guard !disposable.isDisposed else { return }
-      
-      if let error = error {
-        completionHandler(error)
-      } else {
-        completionHandler(nil)
-      }
-    }
-  }
-  
-  public func logout(resetToAnonymous: Bool = false) -> Completable {
-    return Completable.deferred { [unowned self] in
-      if resetToAnonymous && self.isAnonymous { return .error(UserError.alreadyAnonymous) }
-      
-      var logoutAction = Completable.create { (observer) -> Disposable in
-        let disposable = Disposables.create { }
-        
-        do {
-          try Auth.auth().signOut()
-          observer(.completed)
-        } catch {
-          observer(.error(self.map(error: error)))
-        }
-        
-        return disposable
-      }
-      
-      if (resetToAnonymous) {
-        logoutAction = logoutAction
-          .andThen(self.loginAnonymously())
-      }
-      
-      return logoutAction
-    }
-  }
-  
-  public func update(user: UserData) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard let currentUser = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
-      
-      return Completable.create { [unowned self] (observer) -> Disposable in
-        let disposable = Disposables.create { }
-        
-        let changeRequest = currentUser.createProfileChangeRequest()
-        changeRequest.displayName = user.displayName
-        
-        changeRequest.commitChanges { (error) in
-          if let error = error {
-            observer(.error(self.map(error: error)))
-          } else {
-            self.forceRefreshAutoUpdatingUser.onNext(())
-            observer(.completed)
-          }
-        }
-        
-        return disposable
-      }
-    }
-  }
-  
-  public func update(userConfigurationHandler: @escaping (UserData) -> UserData) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard Auth.auth().currentUser != nil else { return Completable.error(UserError.noUser) }
-      
-      return self.autoupdatingUser
-        .take(1)
-        .filter { $0 != nil }.map { $0! }
-        .map(userConfigurationHandler)
-        .flatMap { [unowned self] in self.update(user: $0) }
-        .asCompletable()
-    }
-  }
-  
-  public func updateEmail(newEmail: String) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
-      
-      return Completable.create { (observer) -> Disposable in
-        let disposable = Disposables.create { }
-        
-        user.updateEmail(to: newEmail) { (error) in
-          if let error = error {
-            observer(.error(self.map(error: error)))
-          } else {
-            observer(.completed)
-          }
-        }
-        
-        return disposable
-      }
-    }
-  }
-	
-	public func verifyAndChange(toNewEmail newEmail: String) -> Completable {
-		return Completable.deferred { [unowned self] in
-			guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
+	/// Sign in with the passed credentials in the specified disposable
+	/// and calls the completion handler when done.
+	///
+	/// To use this function directly, you should wrap it inside an `Observable.create`
+	/// function call. This function will check automatically if the passed disposable has already been
+	/// disposed when coming back from `Auth`'s `signIn(with:)` function.
+	///
+	/// - parameters:
+	///     - credentials: The credential to use to sign in.
+	///     - disposable: A disposable that controls the life of this operation.
+	///     - completionHandler: A completion handler to call when done.
+	func signIn(with credentials: AuthCredential, in disposable: Cancelable, completionHandler: @escaping (Error?) -> Void) {
+		Auth.auth().signIn(with: credentials) { (_, error) in
+			guard !disposable.isDisposed else { return }
 			
-			return Completable.create { (observer) -> Disposable in
-				let disposable = Disposables.create { }
-				
-				user.sendEmailVerification(beforeUpdatingEmail: newEmail) { (error) in
-					if let error = error {
-						observer(.error(self.map(error: error)))
-					} else {
-						observer(.completed)
-					}
-				}
-				
-				return disposable
+			if let error = error {
+				completionHandler(error)
+			} else {
+				completionHandler(nil)
 			}
 		}
 	}
-  
-  public func confirmAuthentication(email: String, password: String) -> Completable {
-		confirmAuthentication(
-			with: .password(email: email, password: password)
-		)
-  }
-  
-  public func confirmAuthentication(with loginCredentials: Credentials) -> Completable {
-    return Completable.create { (observer) -> Disposable in
-      let disposable = Disposables.create { }
-      
-      guard let user = Auth.auth().currentUser else { observer(.error(UserError.noUser)); return disposable }
-      
-      user.reauthenticate(with: loginCredentials.asAuthCredentials()) { (_, error) in
-        guard !disposable.isDisposed else { return }
-        if let error = error {
-          observer(.error(self.map(error: error)))
-        } else {
-          observer(.completed)
-        }
-      }
-      
-      return disposable
-    }
-  }
-  
-  public func deleteUser(resetToAnonymous: Bool) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
-      
-      var deleteAction = Completable.create { (observer) -> Disposable in
-        let disposable = Disposables.create { }
-        
-        user.delete { (error) in
-          guard !disposable.isDisposed else { return }
-          if let error = error {
-            observer(.error(self.map(error: error)))
-          } else {
-            observer(.completed)
-          }
-        }
-        
-        return disposable
-      }
-      
-      if resetToAnonymous {
-        deleteAction = deleteAction
-          .andThen(self.loginAnonymously())
-      }
-      
-      return deleteAction
-    }
-  }
-  
-  public func updatePassword(newPassword: String) -> Completable {
-    return Completable.deferred { [unowned self] in
-      guard let user = Auth.auth().currentUser else { return Completable.error(UserError.noUser) }
-      
-      if self.user!.authenticationProviders.contains(.password) {
-        return Completable.create { (observer) -> Disposable in
-          let disposable = Disposables.create { }
-          
-          user.updatePassword(to: newPassword) { (error) in
-            guard !disposable.isDisposed else { return }
-            if let error = error {
-              observer(.error(self.map(error: error)))
-            } else {
-              observer(.completed)
-            }
-          }
-          
-          return disposable
-        }
-      } else {
-        guard let email = user.email else { return Completable.error(UserError.invalidEmail) }
-        return self.link(user: user, toEmail: email, withPassword: newPassword)
-      }
-    }
-  }
-  
-  /// Map a generic error to a `UserError`.
-  ///
-  /// For more info on all the Firebase errors,
-  /// refer to the [Firebase Documentation](https://firebase.google.com/docs/auth/ios/errors)
-  ///
-  /// - parameters:
-  ///     - error: A error.
-  /// - returns: A `UserError` wrapping the error.
-  func map(error: Error) -> UserError {
-    let nsError = error as NSError
-    
-    switch nsError.code {
-    case AuthErrorCode.networkError.rawValue:
-      return .networkError
-    case AuthErrorCode.userNotFound.rawValue:
-      return .userNotFound
-    case AuthErrorCode.userTokenExpired.rawValue:
-      return .expiredToken
-    case AuthErrorCode.invalidEmail.rawValue:
-      return .invalidEmail
-    case AuthErrorCode.userDisabled.rawValue:
-      return .userDisabled
-    case AuthErrorCode.wrongPassword.rawValue:
-      return .wrongPassword
-    case AuthErrorCode.invalidCredential.rawValue:
-      return .invalidCredential
-    case AuthErrorCode.emailAlreadyInUse.rawValue:
-      return .emailAlreadyInUse
-    case AuthErrorCode.operationNotAllowed.rawValue:
-      return .configurationError
-    case AuthErrorCode.invalidAPIKey.rawValue, AuthErrorCode.appNotAuthorized.rawValue, AuthErrorCode.appNotVerified.rawValue:
-      return .invalidConfiguration
-    case AuthErrorCode.weakPassword.rawValue:
-      return .weakPassword(nsError.userInfo[NSLocalizedFailureReasonErrorKey] as? String)
-    case AuthErrorCode.keychainError.rawValue:
-      return .keychainError(error)
-    case AuthErrorCode.userMismatch.rawValue:
-      return .wrongUser
-    case AuthErrorCode.requiresRecentLogin.rawValue:
-      return .authenticationConfirmationRequired
-    case AuthErrorCode.providerAlreadyLinked.rawValue:
-      return .providerAlreadyLinked
-    default:
-      return .unknown(error)
-    }
-  }
-  
+	
+	/// Link the passed user to the Email & Password authentication provider.
+	///
+	/// - parameters:
+	///     - user: A user.
+	///     - email: The email address.
+	///     - password: A password.
+	/// - returns: A Completable action to observe.
+	private func link(user: User, to credentials: Credentials) -> Completable {
+		return Completable.create { [unowned self] (observer) -> Disposable in
+			let disposable = Disposables.create { }
+			
+			let authCredentials = credentials.asAuthCredentials()
+			user.link(with: authCredentials) { (_, error) in
+				guard !disposable.isDisposed else { return }
+				
+				if let error = error {
+					observer(.error(map(error: error)))
+				} else {
+					forceRefreshAutoUpdatingUser.onNext(())
+					observer(.completed)
+				}
+			}
+			
+			return disposable
+		}
+	}
+}
+
+// MARK: - Errors
+private extension UserManager {
+	/// Map a generic error to a `UserError`.
+	///
+	/// For more info on all the Firebase errors,
+	/// refer to the [Firebase Documentation](https://firebase.google.com/docs/auth/ios/errors)
+	///
+	/// - parameters:
+	///     - error: A error.
+	/// - returns: A `UserError` wrapping the error.
+	func map(error: Error) -> UserError {
+		let nsError = error as NSError
+		
+		switch nsError.code {
+		case AuthErrorCode.networkError.rawValue:
+			return .networkError
+		case AuthErrorCode.userNotFound.rawValue:
+			return .userNotFound
+		case AuthErrorCode.userTokenExpired.rawValue:
+			return .expiredToken
+		case AuthErrorCode.invalidEmail.rawValue:
+			return .invalidEmail
+		case AuthErrorCode.userDisabled.rawValue:
+			return .userDisabled
+		case AuthErrorCode.wrongPassword.rawValue:
+			return .wrongPassword
+		case AuthErrorCode.invalidCredential.rawValue:
+			return .invalidCredential
+		case AuthErrorCode.emailAlreadyInUse.rawValue:
+			return .emailAlreadyInUse
+		case AuthErrorCode.operationNotAllowed.rawValue:
+			return .configurationError
+		case AuthErrorCode.invalidAPIKey.rawValue, AuthErrorCode.appNotAuthorized.rawValue, AuthErrorCode.appNotVerified.rawValue:
+			return .invalidConfiguration
+		case AuthErrorCode.weakPassword.rawValue:
+			return .weakPassword(nsError.userInfo[NSLocalizedFailureReasonErrorKey] as? String)
+		case AuthErrorCode.keychainError.rawValue:
+			return .keychainError(error)
+		case AuthErrorCode.userMismatch.rawValue:
+			return .wrongUser
+		case AuthErrorCode.requiresRecentLogin.rawValue:
+			return .authenticationConfirmationRequired
+		case AuthErrorCode.providerAlreadyLinked.rawValue:
+			return .providerAlreadyLinked
+		default:
+			return .unknown(error)
+		}
+	}
 }

--- a/RxFireAuth/Classes/UserManagerType.swift
+++ b/RxFireAuth/Classes/UserManagerType.swift
@@ -15,10 +15,9 @@ import RxSwift
 /// reference this protocol instead of the default implementation `UserManager`,
 /// as this protocol will always conform to Semantic Versioning.
 ///
-/// All methods of this protocol are wrapped inside a Rx object that
+/// All reactive methods of this protocol are wrapped inside a Rx object that
 /// will not execute any code until somebody subscribes to it.
 public protocol UserManagerType {
-  
   /// Get the current login handler.
   ///
   /// This property holds a reference to the handler that is being used
@@ -34,49 +33,28 @@ public protocol UserManagerType {
   /// Get if there is an anonymous user logged-in.
   var isAnonymous: Bool { get }
   
-  /// Get the currently logged-in user or nil if no user is logged-in.
+  /// Get the currently logged-in user or `nil` if no user is logged-in.
+	///
+	/// - note: Use ``autoupdatingUser`` if you need to observe changes
+	/// to the logged-in user.
   var user: UserData? { get }
   
-  /// Get an Observable that emits a new item every time the logged-in user is updated.
+  /// Get an Observable that emits a new item every time the logged-in user changes
+	/// or is updated.
   var autoupdatingUser: Observable<UserData?> { get }
   
   /// Get the current access token for the logged-in user.
   ///
   /// You can use values from this Observable to authenticate with your backend.
-  /// This function will cause a refresh of the access token if the stored one is expired,
-  /// so you don't have to worry about that.
+  /// This function will cause a refresh of the access token if the stored one is expired.
   ///
   /// - warning: The access token should be treated as sensitive information.
   /// - since: version 2.0.0
   var accessToken: Single<String?> { get }
+	
+	// MARK: - Login
   
-  /// Verify if an account exists on the server with the passed email address.
-  ///
-	/// - warning: This query will always return `false` if your project is using Email Enumeration Protection.
-	///
-	///	- seealso: https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection
-  /// - parameters:
-  ///     - email: The account email address.
-  /// - returns: A Single that completes with the result of the query on the backend.
-	@available(*, deprecated, message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, this query will always return false.")
-  func accountExists(with email: String) -> Single<Bool>
-  
-  /// Register a new account on the server with the passed email and password.
-  ///
-  /// - note: The resulting Completable will emit `UserError.alreadyLoggedIn` if there is already
-  ///         a non-anonymous user logged-in. If the logged-in user is anonymous, this function
-  ///         will call `self.linkAnonymousAccount` and return that value.
-  ///
-  /// - note: After registering, the new user will become the currently logged-in user
-  ///         automatically.
-  ///
-  /// - parameters:
-  ///     - email: The user email address.
-  ///     - password: The user password.
-  /// - returns: A Completable action to observe.
-  func register(email: String, password: String) -> Completable
-  
-  /// Login an anonymous user.
+  /// Login with an anonymous user.
   ///
   /// - note: You can use this method to create an anonymous user on the server.
   ///
@@ -87,70 +65,127 @@ public protocol UserManagerType {
   /// - returns: A Completable action to observe.
   func loginAnonymously() -> Completable
   
-  /// Convert an anonymous user to a normal user with an email and a password.
-  ///
-  /// - note: The resulting Completable will emit `UserError.noUser` if the currently logged-in user
-  ///         is not anonymous or is nil.
-  ///
-  /// - parameters:
-  ///     - email: The user email address.
-  ///     - password: The user password.
-  /// - returns: A Completable action to observe.
-  func linkAnonymousAccount(toEmail email: String, password: String) -> Completable
-  
   /// Login the user with the specified email address using the specified password.
   ///
   /// - note: This function will return `UserError.alreadyLoggedIn` if there is already
   ///         a non-anonymous user logged-in.
 	///
-	/// - note: This function is a shorthand for calling ``login(with:updateUserDisplayName:allowMigration:)`` passing
-	/// ``Credentials.password``.
+	/// - note: 	This function is a shorthand for
+	///        	calling ``login(with:updateUserDisplayName:allowMigration:resetToAnonymousOnFailure:)`` passing
+	/// 				``Credentials.password``.
+	///
+	/// - seealso: ``login(with:updateUserDisplayName:allowMigration:resetToAnonymousOnFailure:)``.
   ///
   /// - parameters:
   ///     - email: The user email address.
   ///     - password: The user password.
-  ///     - allowMigration: An optional boolean that defines the behavior in case there is an anonymous user logged-in and the user is trying to login into an existing account. This option will be passed back to the caller
-  ///     in the resulting `LoginDescriptor.performMigration`; if set to `nil`, the operation will not proceed and a `UserError.migrationRequired` error will be emitted by the Single.
+  ///     - allowMigration: An optional boolean that defines the behavior in case there is an anonymous user logged-in 
+	///     							and the user is trying to login into an existing account. This option will be passed back to the caller
+  ///     							in the resulting `LoginDescriptor.performMigration`;
+	///     							if set to `nil`, the operation will not proceed and a `UserError.migrationRequired` error will be emitted by the Single.
+	///     - resetToAnonymousOnFailure: 	If `true`, this function will call `loginAnonymously()` if the login operation fails.
+	///     													This only applies to password-based authentication when linking an existing account
+	///     													to an anonymous one. It will be invoked when the provided credentials are invalid.
+	///     													A migration will always be required in this case, because the previous anonymous account will be lost.
   /// - returns: A Single that emits errors or a `LoginDescriptor` instance.
-  func login(email: String, password: String, allowMigration: Bool?) -> Single<LoginDescriptor>
-  
-  /// Sign in with the passed credentials without first checking if an account
-  /// with the specified email address exists on the backend.
-  ///
-  /// - parameters:
-  ///     - email: An email address.
-  ///     - password: A password.
-  ///     - allowMigration: An optional boolean that defines the behavior in case there is an anonymous user logged-in and the user is trying to login into an existing account. This option will be passed back to the caller
-  ///     in the resulting `LoginDescriptor.performMigration`; if set to `nil`, the operation will not proceed and a `UserError.migrationRequired` error will be emitted by the Single.
-  /// - returns: A Single to observe for results.
-	@available(*, deprecated, message: "Use the other login functions instead. With Email Enumeration Protection, it is no longer possible to check whether an account exists, so the normal `login` function now behaves exactly like this one used to do.")
-  func loginWithoutChecking(email: String, password: String, allowMigration: Bool?) -> Single<LoginDescriptor>
-  
-  /// Sign in with the passed credentials on a login provider.
+	@available(*, deprecated, renamed: "login(with:updateUserDisplayName:allowMigration:resetToAnonymousOnFailure:)", message: "Invoke the generic login function passing `Credentials.password`.")
+	func login(
+		email: String,
+		password: String,
+		allowMigration: Bool?,
+		resetToAnonymousOnFailure: Bool
+	) -> Single<LoginDescriptor>
+	
+  /// Login the user with the specified credentials.
 	///
-  /// - since: version 1.3.0
+  /// - since: version 6.0.0
 	///
 	/// - note: This function will fail when attempting to login with `Credentials.password` on an account that has no password set.
   ///
   /// - parameters:
   ///     - credentials: Credentials to use to login.
-  ///     - updateUserDisplayName: If the passed credentials result in a successful login and this is set to `true`, this function will attempt to update the user display name by reading it from the resulting `LoginDescriptor`.
-  ///     - allowMigration: An optional boolean that defines the behavior in case there is an anonymous user logged-in and the user is trying to login into an existing account. This option will be passed back to the caller
-  ///     in the resulting `LoginDescriptor.performMigration`; if set to `nil`, the operation will not proceed and a `UserError.migrationRequired` error will be emitted by the Single.
+  ///     - updateUserDisplayName: 	If the passed credentials result in a successful login and this is set to `true`,
+	///     												this function will attempt to update the user display name
+	///     												by reading it from the resulting `LoginDescriptor`.
+  ///     - allowMigration: 	An optional boolean that defines the behavior in case
+	///     								there is an anonymous user logged-in and the user
+	///     								is trying to login into an existing account.
+	///     								This option will be passed back to the caller in the
+	///     								resulting `LoginDescriptor.performMigration`;
+	///     								if set to `nil`, the operation will not proceed and a `UserError.migrationRequired`
+	///     								error will be emitted instead.
+	///     - resetToAnonymousOnFailure: 	If `true`, this function will call `loginAnonymously()`
+	///     													if the login operation fails. This only applies to password-based
+	///     													authentication when linking an existing
+	///     													account to an anonymous one. It will be invoked
+	///     													when the provided credentials are invalid.
+	///     													A migration will always be required in this case,
+	///     													because the previous anonymous account will be lost.
   /// - returns: A Single to observe for results.
-  func login(with credentials: Credentials, updateUserDisplayName: Bool, allowMigration: Bool?) -> Single<LoginDescriptor>
+	func login(
+		with credentials: Credentials,
+		updateUserDisplayName: Bool,
+		allowMigration: Bool?,
+		resetToAnonymousOnFailure: Bool
+	) -> Single<LoginDescriptor>
   
   /// Sign out the currently logged-in user.
   ///
   /// Using the `resetToAnonymous` parameter, you can make sure
-  /// that there is always a user signed in; in fact, if the parameter is set to `true`, this
-  /// function will call `loginAnonymously()` immediately after the logout operation has completed.
+  /// that there is always a user signed in: if the parameter is set to `true`, this
+  /// function will call ``loginAnonymously()`` immediately after the logout operation has completed.
   ///
   /// - parameters:
   ///     - resetToAnonymous: If `true`, after having logged-out successfully, this function will immediately sign in a new anonymous user.
   /// - returns: A Completable action to observe.
   func logout(resetToAnonymous: Bool) -> Completable
+	
+	// MARK: - Manual Registration
+	
+	/// Register a new account on the server with the passed email and password.
+	///
+	/// - note: The resulting Completable will emit `UserError.alreadyLoggedIn` if there is already
+	///         a non-anonymous user logged-in. If the logged-in user is anonymous, this function
+	///         will call `self.linkAnonymousAccount` and return that value.
+	///
+	/// - note: After registering, the new user will become the currently logged-in user
+	///         automatically.
+	///
+	/// - parameters:
+	///     - email: The user email address.
+	///     - password: The user password.
+	/// - returns: A Completable action to observe.
+	func register(email: String, password: String) -> Completable
+	
+	// MARK: - Manual Linking
+	
+	/// Convert an anonymous user to a user with a email and a password.
+	///
+	/// - note: This function is a shorthand for calling ``linkAnonymousAccount(to:)`` passing ``Credentials.password``.
+	///
+	/// - parameters:
+	///     - email: The user email address.
+	///     - password: The user password.
+	/// - returns: A Completable action to observe.
+	@available(*, deprecated, renamed: "linkAnonymousAccount(to:)", message: "Invoke the generic link function passing `Credentials.password`.")
+	func linkAnonymousAccount(toEmail email: String, password: String) -> Completable
+	
+	/// Convert an anonymous account to an account that can login with the passed credentials.
+	///
+	/// - note: This function will fail if the passed credentials are already associated with another account.
+	/// 				To support this use case,
+	/// 				use ``login(with:updateUserDisplayName:allowMigration:resetToAnonymousOnFailure:)`` instead.
+	///
+	/// - note: This function will fail with ``UserError.noUser`` if there is no anonymous user logged-in.
+	///
+	/// - since: version 6.0.0.
+	/// - parameters:
+	/// 	- credentials: The credentials to link to the anonymous account.
+	/// - returns: A Completable action to observe.
+	func linkAnonymousAccount(to credentials: Credentials) -> Completable
   
+	// MARK: - Update User
+	
   /// Update the currently signed in user taking new values from the
   /// passed object.
   ///
@@ -160,7 +195,7 @@ public protocol UserManagerType {
   ///
   /// - note: This function will not update the user email address, even if it has changed.
   ///
-  /// - seealso: self.update(userConfigurationHandler:)
+  /// - seealso: ``update(userConfigurationHandler:)``
   /// - parameters:
   ///     - user: A user to gather new values from.
   /// - returns: A Completable action to observe.
@@ -169,8 +204,8 @@ public protocol UserManagerType {
   /// Update the currently signed in user by retrieving its value and passing it
   /// to the `userConfigurationHandler`.
   ///
-  /// - note: This function is a shorthand that takes the first value of `self.autoUpdatingUser`,
-  /// maps it by calling `userConfigurationHandler` and passes the result to `self.updateUser(user:)`.
+  /// - note: This function is a shorthand that takes the first value of ``autoupdatingUser``,
+  /// 				maps it by calling `userConfigurationHandler` and passes the result to ``update(user:)``.
   ///
   /// - since: version 1.1.0
   ///
@@ -179,17 +214,30 @@ public protocol UserManagerType {
   /// - returns: A Completable action to observe.
   func update(userConfigurationHandler: @escaping (UserData) -> UserData) -> Completable
   
+	// MARK: - Email Management
+	
+	/// Verify if an account exists on the server with the passed email address.
+	///
+	/// - warning: This query will always return `false` if your project is using Email Enumeration Protection.
+	///
+	///	- seealso: [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection)
+	/// - parameters:
+	///     - email: The account email address.
+	/// - returns: A Single that completes with the result of the query on the backend.
+	@available(*, deprecated, message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, this query will always return false.")
+	func accountExists(with email: String) -> Single<Bool>
+	
   /// Update the email of the currently signed in user.
   ///
   /// All users have an email address associated, even those that have signed in using a login provider (such as Google).
   /// Keep in mind that some login providers may return a relay email which may not be enabled to receive messages.
   ///
 	/// - warning: If your project has Email Enumeration Protection enabled, this call will fail.
-	/// - seealso: https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection
+	/// - seealso: [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection)
   /// - parameters:
   ///     - newEmail: The new email address.
   /// - returns: A Completable action to observe.
-	@available(*, deprecated, message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, you should invoke `verifyEmailToUpdate` instead.")
+	@available(*, deprecated, renamed: "verifyAndChange(toNewEmail:)", message: "This function will be removed when it is removed by the Firebase SDK. If your project is using Email Enumeration Protection, you should invoke `verifyAndChange(toNewEmail:)` instead.")
   func updateEmail(newEmail: String) -> Completable
 	
 	/// Send a verification email to the specified email address and, if the verification succeeds,
@@ -206,6 +254,8 @@ public protocol UserManagerType {
 	/// - returns: A Completable action to observe.
 	func verifyAndChange(toNewEmail newEmail: String) -> Completable
   
+	// MARK: - Confirm Authentication
+	
   /// Confirm the authentication of the passed credentials with the currently signed in user.
   ///
   /// You need to confirm the authentication of a user before performing sensitive operations, such
@@ -214,11 +264,14 @@ public protocol UserManagerType {
   /// To confirm the authentication with a login provider (such as Google), use the appropriate method in
   /// the "confirmAuthenticationWith" family, or confirm the authentication by other means and then call
   /// `self.confirmAuthentication(with:)`.
+	///
+	/// - note: This is a shorthand for ``confirmAuthentication(with:)`` passing ``Credentials.password``.
   ///
   /// - parameters:
   ///     - email: The user email address.
   ///     - password: The user password.
   /// - returns: A Completable action to observe.
+	@available(*, deprecated, renamed: "confirmAuthentication(with:)", message: "Invoke the generic confirm function passing `Credentials.password`.")
   func confirmAuthentication(email: String, password: String) -> Completable
   
   /// Confirm the authentication of the passed credentials with the currently signed in user.
@@ -229,15 +282,34 @@ public protocol UserManagerType {
   ///     - loginCredentials: A representation of the credentials used to login.
   /// - returns: A Completable action to observe.
   func confirmAuthentication(with loginCredentials: Credentials) -> Completable
+	
+	// MARK: - Password Management
+	
+	/// Update or set the password of the currently signed in user.
+	///
+	/// If the user does not have `password` among their `authenticationProviders`,
+	/// this function will create a new provider using the user email and the specified password.
+	/// This will basically link the Email & Password authentication to the user.
+	/// If the user already has `password` as an authentication provider, this function will
+	/// simply update their password.
+	///
+	/// - since: version 1.4.0
+	///
+	/// - parameters:
+	///     - newPassword: The new password.
+	/// - returns: A Completable action to observe.
+	func updatePassword(newPassword: String) -> Completable
   
+	// MARK: - Delete User
+	
   /// Delete the currently signed in user.
   ///
   /// This is a sensitive action. If the user hasn't signed in recently, you'll need to confirm the authentication
-  /// through one of the methods in the "confirmAuthenticationWith…" family.
+  /// by invoking ``confirmAuthentication(with:)``.
   ///
   /// Using the `resetToAnonymous` parameter, you can make sure
-  /// that there is always a user signed in; in fact, if the parameter is set to `true`, this
-  /// function will call `loginAnonymously()` immediately after the logout operation has completed.
+  /// that there is always a user signed in; if the parameter is set to `true`, this
+  /// function will call ``loginAnonymously()`` immediately after the logout operation has completed.
   ///
   /// - since: version 1.4.0
   ///
@@ -245,20 +317,5 @@ public protocol UserManagerType {
   ///     - resetToAnonymous: If `true`, after having deleted the account successfully, this function will immediately sign in a new anonymous user.
   /// - returns: A Completable action to observe.
   func deleteUser(resetToAnonymous: Bool) -> Completable
-  
-  /// Update or set the password of the currently signed in user.
-  ///
-  /// If the user does not have `password` among their `authenticationProviders`,
-  /// this function will create a new provider using the user email and the specified password.
-  /// This will basically link the Email & Password authentication to the user.
-  /// If the user already has `password` as an authentication provider, this function will
-  /// simply update their password.
-  ///
-  /// - since: version 1.4.0
-  ///
-  /// - parameters:
-  ///     - newPassword: The new password.
-  /// - returns: A Completable action to observe.
-  func updatePassword(newPassword: String) -> Completable
   
 }


### PR DESCRIPTION
# Overview
This PR closes #14 and improves the code quality and readability. It also deprecates all functions that make use of `email` and `password` directly in favor of the generic implementation with `Credentials`.